### PR TITLE
Change xmlErrorPtr into const xmlError* for libxml2 >= 2.12 compatibility

### DIFF
--- a/nv-attestation-sdk-cpp/src/rim.cpp
+++ b/nv-attestation-sdk-cpp/src/rim.cpp
@@ -61,7 +61,7 @@ Error RimDocument::create_from_rim_data(const std::string &rim_data, RimDocument
     //    TCG from CORIM
     auto doc = nv_unique_ptr<xmlDoc>(xmlReadDoc(reinterpret_cast<const xmlChar *>(rim_data.c_str()), NULL, NULL, XML_PARSE_PEDANTIC | XML_PARSE_NONET));
     if (!doc) {
-        xmlErrorPtr xml_error = xmlGetLastError();
+        const xmlError* xml_error = xmlGetLastError();
         std::string error_msg = "Failed to parse RIM data as TCG XML file. ";
         if (xml_error != nullptr) {
             error_msg += "XML error: " + std::string(xml_error->message);


### PR DESCRIPTION
Bump libxml to >= 2.12 (released in 2023).

Libxml made a breaking change in 2.12 where `xmlGetLastError()` would return `const xmlError*` instead of just `xmlError*`