### PR TITLE
fix(cmakelists): add hidden zlib dependency to cpp sdk

### DIFF
--- a/nv-attestation-sdk-cpp/CMakeLists.txt
+++ b/nv-attestation-sdk-cpp/CMakeLists.txt
@@ -130,6 +130,7 @@ find_package(CURL REQUIRED)
 find_package(LibXml2 REQUIRED)
 find_package(OpenSSL REQUIRED)
 find_package(xmlsec REQUIRED)
+find_package(ZLIB REQUIRED)
 
 add_compile_options(-Wall -Wextra -Wpedantic -pedantic)
 if (CMAKE_VERSION VERSION_LESS 3.24.0 AND CMAKE_COMPILE_WARNING_AS_ERROR)
@@ -239,6 +240,7 @@ target_link_libraries(nvat
     OpenSSL::Crypto
     CURL::libcurl
     LibXml2::LibXml2
+    ZLIB::ZLIB
     # Use TARGET_FILE to link the static library directly without creating
     # a target dependency that CMake would try to export
     $<TARGET_FILE:spdlog>

--- a/nv-attestation-sdk-cpp/CMakeLists.txt
+++ b/nv-attestation-sdk-cpp/CMakeLists.txt
@@ -291,6 +291,8 @@ else()
 
 endif() # USE_SYSTEM_DEPS
 
+find_package(ZLIB REQUIRED)
+
 add_compile_options(-Wall -Wextra -Wpedantic -pedantic)
 if (CMAKE_VERSION VERSION_LESS 3.24.0 AND CMAKE_COMPILE_WARNING_AS_ERROR)
   add_compile_options(-Werror)
@@ -398,6 +400,7 @@ target_link_libraries(nvat
     OpenSSL::Crypto
     CURL::libcurl
     LibXml2::LibXml2
+    ZLIB::ZLIB
     # Use TARGET_FILE to link the static library directly without creating
     # a target dependency that CMake would try to export
     $<TARGET_FILE:spdlog>


### PR DESCRIPTION
`nvat` was pulling in zlib transitively (via libxml2/xmlsec), which fails to link on toolchains that don't propagate transitive libs.
Add `find_package(ZLIB REQUIRED)` and `ZLIB::ZLIB` to `nvat`'s `target_link_libraries`, matching how the other deps (OpenSSL, CURL, LibXml2) are declared.
