### PR TITLE
chore(github): add issue templates and stale workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: '[Bug]: '
+labels: ["bug", "needs-triage"]
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Detailed steps to reproduce the issue.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Environment (please provide the following information):**
+ - `nvtrust` / SDK version: [e.g. `v1.2.0`]
+ - NVIDIA Driver Version: [e.g. 550.54.15]
+ - Host OS: [e.g. Ubuntu 22.04]
+ - Kernel Version: [e.g. 5.15.0-generic]
+ - CPU Architecture: [e.g. `x86_64`, `aarch64`]
+ - GPU Model(s): [e.g. H100, B200, GB200]
+ - GPU Firmware Version: [e.g. 97.00.5a.00.02]
+ - Deployment: [e.g. Bare-metal, Docker, Kubernetes]
+ - Verifier type: [e.g. Local Verifier, NRAS]
+
+If applicable, also provide:
+ - Container Runtime Version: [e.g. containerd 1.7.0]
+ - Kubernetes Distro and Version: [e.g. K8s 1.29, OpenShift 4.14]
+ - NVIDIA GPU Operator version
+
+**Relevant log output**
+Please paste relevant error and log output here.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,9 @@
+blank_issues_enabled: false
+
+contact_links:
+  - name: Ask a Question / General Discussion
+    url: https://github.com/NVIDIA/attestation-sdk/discussions
+    about: Please use GitHub Discussions for questions and general discussion.
+  - name: Report a Security Vulnerability
+    url: https://www.nvidia.com/object/submit-security-vulnerability.html
+    about: Please do not report security vulnerabilities through GitHub issues. Use the NVIDIA Security Vulnerability Submission Form instead.

--- a/.github/ISSUE_TEMPLATE/documentation_request.md
+++ b/.github/ISSUE_TEMPLATE/documentation_request.md
@@ -1,0 +1,33 @@
+---
+name: Documentation request or correction
+about: Report incorrect documentation or request new documentation
+title: '[Doc]: '
+labels: ["documentation", "needs-triage"]
+
+---
+
+<!-- Fill out the relevant section below and delete the unused one. -->
+
+## Report incorrect or outdated documentation
+
+**Location of incorrect documentation**
+Provide a link and line numbers if applicable.
+
+**Describe the problem**
+A clear and concise description of what is incorrect or outdated.
+
+**Suggested fix**
+Describe the proposed correction if you have one.
+
+---
+
+## Request new documentation
+
+**Describe the missing documentation**
+A clear and concise description of what documentation is needed and why.
+
+**Where have you looked?**
+List any docs, READMEs, or sources you've already checked.
+
+**Additional context**
+Add any other context here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature request
+about: Suggest new or improved functionality
+title: '[Feature]: '
+labels: ["feature request", "needs-triage"]
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of the problem. Ex. I'm working on X and would like Y to be possible.
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or approaches you've considered.
+
+**Additional context**
+Add any other context, code examples, references or screenshots about the feature request here.

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,25 @@
+name: Stale issues
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "21 4 * * *"
+
+jobs:
+  stale:
+    permissions:
+      actions: write
+      issues: write
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/stale@v10
+        with:
+          stale-issue-message: 'This issue is stale because it has been open 90 days with no activity. This issue will be closed in 30 days unless new comments are made or the stale label is removed. To skip these checks, apply the "lifecycle/frozen" label.'
+          stale-issue-label: 'lifecycle/stale'
+          exempt-issue-labels: 'lifecycle/frozen,feature request,enhancement'
+          days-before-stale: 90
+          close-issue-message: 'This issue was automatically closed due to inactivity.'
+          days-before-issue-close: 30
+          remove-stale-when-updated: true
+          operations-per-run: 1000

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 */target/*
 */build/*
 *_build*
-*_repo*
+*_repo/
 build_docs/
 build/
 


### PR DESCRIPTION
                                                                                                                                                                                                                                                                                                                                                                         
  - Add GitHub issue templates for Bug, Feature Request, and Documentation reports                                                                                                          
  - Add `config.yml` to disable blank issues and redirect security reports to the NVIDIA PSIRT form and questions to GitHub Discussions                                                     
  - Add GitHub Actions stale workflow: marks issues inactive after 90 days, closes them after a further 30 days; issues labeled `lifecycle/frozen`, `feature request`, or `enhancement` are 
  exempt   