### PR TITLE
Release 2026.04.29

### DIFF
--- a/nv-attestation-cli/CMakeLists.txt
+++ b/nv-attestation-cli/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.11)
-project(nvattest VERSION 1.2.0)
+project(nvattest VERSION 1.2.1)
 
 option(BUILD_TESTING "Build tests" OFF)
 option(USE_SYSTEM_NVAT "Compile and link to the system nvat library. If OFF, nvat will be built from source." OFF)

--- a/nv-attestation-sdk-cpp/CMakeLists.txt
+++ b/nv-attestation-sdk-cpp/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.11)
-project(nv-attestation VERSION 1.2.0)
+project(nv-attestation VERSION 1.2.1)
 
 set(CMAKE_CXX_STANDARD 14 CACHE STRING
   "The C++ standard whose features are requested to build this target."

--- a/nv-attestation-sdk-cpp/src/switch/evidence.cpp
+++ b/nv-attestation-sdk-cpp/src/switch/evidence.cpp
@@ -425,10 +425,9 @@ Error SwitchEvidence::AttestationReport::get_vbios_rim_id(std::string& out_vbios
         return error;
     }
 
-    // remove "." from vbios_version
+    // clean vbios_version: remove . and ensure uppercase
     vbios_version.erase(std::remove(vbios_version.begin(), vbios_version.end(), '.'), vbios_version.end());
-    // make it lowercase
-    std::transform(vbios_version.begin(), vbios_version.end(), vbios_version.begin(), ::tolower);
+    std::transform(vbios_version.begin(), vbios_version.end(), vbios_version.begin(), ::toupper);
 
     SwitchArchitectureData arch_data;
     error = SwitchArchitectureData::create(architecture, arch_data);

--- a/nv-attestation-sdk-rust/Cargo.toml
+++ b/nv-attestation-sdk-rust/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 authors = ["NVIDIA Corporation"]
 license = "Apache-2.0"

--- a/nv-attestation-sdk-rust/nv-attestation-sdk/Cargo.toml
+++ b/nv-attestation-sdk-rust/nv-attestation-sdk/Cargo.toml
@@ -11,7 +11,7 @@ description = "Safe Rust bindings for the NVIDIA Attestation SDK"
 documentation = "https://docs.nvidia.com/attestation/nv-attestation-sdk-rust/latest/overview.html"
 
 [dependencies]
-nv-attestation-sdk-sys = { version = "1.2.0", path = "../nv-attestation-sdk-sys" }
+nv-attestation-sdk-sys = { version = "1.2.1", path = "../nv-attestation-sdk-sys" }
 log = { version = "0.4", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
## Bug Fixes

* NVSwitch VBIOS version was not properly normalized for RIM lookup, causing failed RIM lookups for specific versions.

## Components

* nvattest 1.2.1
* libnvat and libnvat-dev 1.2.1
* nv-attestation-sdk-rust 1.2.1