### PR TITLE
#24 - Pin the nlohmann/json download by hash

### DIFF
--- a/nv-attestation-cli/CMakeLists.txt
+++ b/nv-attestation-cli/CMakeLists.txt
@@ -19,7 +19,7 @@ FetchContent_Declare(
     GIT_TAG v2.6.1
 )
 
-FetchContent_Declare(json URL https://github.com/nlohmann/json/releases/download/v3.12.0/json.tar.xz EXCLUDE_FROM_ALL)
+FetchContent_Declare(json URL https://github.com/nlohmann/json/releases/download/v3.12.0/json.tar.xz URL_HASH SHA256=42f6e95cad6ec532fd372391373363b62a14af6d771056dbfc86160e6dfff7aa EXCLUDE_FROM_ALL)
 FetchContent_MakeAvailable(CLI11 json)
 
 add_executable(nvattest

--- a/nv-attestation-cli/tests/CMakeLists.txt
+++ b/nv-attestation-cli/tests/CMakeLists.txt
@@ -25,7 +25,7 @@ target_compile_options(nv-attestation-cli-tests PRIVATE -Wno-unused -Wno-c++17-a
 
 include(FetchContent)
 
-FetchContent_Declare(json URL https://github.com/nlohmann/json/releases/download/v3.12.0/json.tar.xz)
+FetchContent_Declare(json URL https://github.com/nlohmann/json/releases/download/v3.12.0/json.tar.xz URL_HASH SHA256=42f6e95cad6ec532fd372391373363b62a14af6d771056dbfc86160e6dfff7aa)
 FetchContent_MakeAvailable(json)
 
 FetchContent_Declare(

--- a/nv-attestation-sdk-cpp/CMakeLists.txt
+++ b/nv-attestation-sdk-cpp/CMakeLists.txt
@@ -89,7 +89,7 @@ target_include_directories(own-jwt-cpp
 # but it should work with c++14 also. so disable this warning.
 target_compile_options(own-jwt-cpp INTERFACE -Wno-c++17-extensions)
 
-FetchContent_Declare(json URL https://github.com/nlohmann/json/releases/download/v3.12.0/json.tar.xz EXCLUDE_FROM_ALL)
+FetchContent_Declare(json URL https://github.com/nlohmann/json/releases/download/v3.12.0/json.tar.xz URL_HASH SHA256=42f6e95cad6ec532fd372391373363b62a14af6d771056dbfc86160e6dfff7aa EXCLUDE_FROM_ALL)
 FetchContent_MakeAvailable(json)
 
 # Build fmt and spdlog as static libraries with PIC (needed for linking into shared libs)

--- a/nv-attestation-sdk-cpp/unit-tests/CMakeLists.txt
+++ b/nv-attestation-sdk-cpp/unit-tests/CMakeLists.txt
@@ -89,7 +89,7 @@ if (SANITIZER)
     target_link_options(nv-attestation-unit-tests PRIVATE -fsanitize=${SANITIZER} -fno-sanitize-recover=all)
 endif()
 
-FetchContent_Declare(json URL https://github.com/nlohmann/json/releases/download/v3.12.0/json.tar.xz)
+FetchContent_Declare(json URL https://github.com/nlohmann/json/releases/download/v3.12.0/json.tar.xz URL_HASH SHA256=42f6e95cad6ec532fd372391373363b62a14af6d771056dbfc86160e6dfff7aa)
 FetchContent_MakeAvailable(json)
 
 # Fetch spdlog and fmt for header access only (nvat has them statically linked)


### PR DESCRIPTION
fixes #24.

adds `URL_HASH SHA256=42f6e95cad6ec532fd372391373363b62a14af6d771056dbfc86160e6dfff7aa` to all four `FetchContent_Declare(json ...)` sites, matching how openssl, xmlsec and curl are already pinned.

all four are needed rather than just the sdk one: `FetchContent` honors the first declaration of a given name, and a cli-root configure declares json before it adds the sdk subdirectory, so the cli declaration is the one that takes effect for the build that produces `nvattest` and `libnvat`.

verified the hash against the published v3.12.0 `json.tar.xz`.
