### PR TITLE
#25 - Stop baking the build host CA bundle path into vendored curl

### DIFF
--- a/nv-attestation-sdk-cpp/CMakeLists.txt
+++ b/nv-attestation-sdk-cpp/CMakeLists.txt
@@ -265,6 +265,9 @@ else()
       --without-libidn2
       --without-librtmp
       --without-libpsl
+      --with-ca-fallback
+      --without-ca-bundle
+      --without-ca-path
       --disable-ldap
       --disable-shared
       --enable-static


### PR DESCRIPTION
fixes #25.

configures the vendored curl with `--with-ca-fallback --without-ca-bundle --without-ca-path`, so no absolute ca path is compiled in and runtime resolution falls back to openssl's own default store.

without these, curl's configure probes the build machine and bakes in the first bundle path it finds. the published redist archive carries `/etc/ssl/certs/ca-certificates.crt` for that reason, which fails with `CURLE_SSL_CACERT_BADFILE` (77) on any host using a different layout.

verified on a build with these flags: neither `libnvat.so` nor `nvattest` contains an `/etc/ssl` or `/etc/pki` string, and https calls resolve on both debian- and rhel-layout hosts.
