### PR TITLE
#26 - Align CLI11 across cli builds and fix cert generation on OpenSSL 1.1.1

### DIFF
--- a/nv-attestation-cli/tests/CMakeLists.txt
+++ b/nv-attestation-cli/tests/CMakeLists.txt
@@ -31,7 +31,7 @@ FetchContent_MakeAvailable(json)
 FetchContent_Declare(
     cli11
     GIT_REPOSITORY https://github.com/CLIUtils/CLI11.git
-    GIT_TAG v2.4.2
+    GIT_TAG v2.6.1
 )
 FetchContent_MakeAvailable(cli11)
 

--- a/nv-attestation-sdk-cpp/unit-tests/testdata/x509_cert_chain/generate_test_certs.sh
+++ b/nv-attestation-sdk-cpp/unit-tests/testdata/x509_cert_chain/generate_test_certs.sh
@@ -35,6 +35,9 @@ generate_root_cert() {
     echo "Creating Root CA configuration..."
     ROOT_CA_CNF="${CERT_DIR}/root_ca.cnf"
     cat > "${ROOT_CA_CNF}" <<EOF
+[ req ]
+distinguished_name = req_dn
+[ req_dn ]
 [ v3_ca ]
 subjectKeyIdentifier = hash
 authorityKeyIdentifier = keyid:always,issuer:always # For a self-signed root, AKID refers to itself
@@ -183,6 +186,9 @@ generate_leaf_cert_wrong_signature() {
     WRONG_ROOT_CA_CNF="${CERT_DIR}/wrong_root_ca.cnf"
 
     cat > "${WRONG_ROOT_CA_CNF}" <<EOF
+[ req ]
+distinguished_name = req_dn
+[ req_dn ]
 [ v3_ca ]
 subjectKeyIdentifier = hash
 authorityKeyIdentifier = keyid:always,issuer:always


### PR DESCRIPTION
fixes #26.

two changes:

1. `nv-attestation-cli/tests/CMakeLists.txt` pins CLI11 `v2.6.1` to match `nv-attestation-cli/CMakeLists.txt`, so the tests exercise the same option parser the cli ships. the tests build against `v2.6.1`.
2. `generate_test_certs.sh` gets `[ req ]` / `distinguished_name` sections in the two generated configs, so `openssl req -x509` works on 1.1.1 as well as 3.x. certificates produced on 3.x are unchanged.

glad to split these into two PRs if you'd rather keep them separate.

note: this touches `nv-attestation-cli/tests/CMakeLists.txt` a few lines away from #24's change to the same file. they merge cleanly in either order.
