### PR TITLE
Keep vendored fmt and spdlog warnings non-fatal

### DIFF
--- a/nv-attestation-cli/CMakeLists.txt
+++ b/nv-attestation-cli/CMakeLists.txt
@@ -105,6 +105,8 @@ target_link_libraries(nvattest PRIVATE
 target_include_directories(nvattest PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/src
     ${CMAKE_CURRENT_BINARY_DIR}
+)
+target_include_directories(nvattest SYSTEM PRIVATE
     ${spdlog_SOURCE_DIR}/include
     ${fmt_SOURCE_DIR}/include
 )

--- a/nv-attestation-cli/tests/CMakeLists.txt
+++ b/nv-attestation-cli/tests/CMakeLists.txt
@@ -67,9 +67,11 @@ target_link_libraries(nv-attestation-cli-tests PRIVATE
 
 # spdlog/fmt headers needed for compilation (nvat has them statically linked, no need to link again)
 target_include_directories(nv-attestation-cli-tests PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src
+)
+target_include_directories(nv-attestation-cli-tests SYSTEM PRIVATE
     ${spdlog_SOURCE_DIR}/include
     ${fmt_SOURCE_DIR}/include
-    ${CMAKE_CURRENT_SOURCE_DIR}/../src
 )
 
 # nvat.h is needed for result codes used by the tests, but the test executable must not link to libnvat.

--- a/nv-attestation-sdk-cpp/CMakeLists.txt
+++ b/nv-attestation-sdk-cpp/CMakeLists.txt
@@ -110,6 +110,7 @@ FetchContent_Declare(
   EXCLUDE_FROM_ALL
 )
 FetchContent_MakeAvailable(fmt)
+set_target_properties(fmt PROPERTIES COMPILE_WARNING_AS_ERROR OFF)
 
 # Build spdlog as static library using our fetched fmt
 set(SPDLOG_INSTALL OFF CACHE BOOL "Don't install spdlog headers" FORCE)
@@ -122,6 +123,7 @@ FetchContent_Declare(
   EXCLUDE_FROM_ALL
 )
 FetchContent_MakeAvailable(spdlog)
+set_target_properties(spdlog PROPERTIES COMPILE_WARNING_AS_ERROR OFF)
 
 # Restore original settings
 set(BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS_SAVED})
@@ -360,9 +362,12 @@ target_include_directories(nvat
     src
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     ${regorus_SOURCE_DIR}/bindings/ffi
-    # spdlog and fmt include dirs (linked statically via TARGET_FILE below)
-    ${spdlog_SOURCE_DIR}/include
-    ${fmt_SOURCE_DIR}/include
+)
+
+# spdlog and fmt include dirs (linked statically via TARGET_FILE below)
+target_include_directories(nvat SYSTEM PRIVATE
+  ${spdlog_SOURCE_DIR}/include
+  ${fmt_SOURCE_DIR}/include
 )
 
 if (SANITIZER)

--- a/nv-attestation-sdk-cpp/unit-tests/CMakeLists.txt
+++ b/nv-attestation-sdk-cpp/unit-tests/CMakeLists.txt
@@ -176,6 +176,8 @@ target_link_libraries(nv-attestation-unit-tests PRIVATE
 # spdlog/fmt headers needed for compilation (nvat has them statically linked, no need to link again)
 target_include_directories(nv-attestation-unit-tests PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/../include
+)
+target_include_directories(nv-attestation-unit-tests SYSTEM PRIVATE
     ${spdlog_SOURCE_DIR}/include
     ${fmt_SOURCE_DIR}/include
 )


### PR DESCRIPTION
## Summary

- disable `COMPILE_WARNING_AS_ERROR` for the vendored fmt and spdlog targets
- classify their include directories as `SYSTEM` at each SDK, CLI, and test consumer without changing first-party include classification

Fixes #32.

## Testing

- configured `nv-attestation-cli` with tests enabled on macOS 26.5, AppleClang 21.0.0, arm64
- built the `fmt` and `spdlog` targets; the libc++ deprecation warnings remain visible but no longer fail the build
- checked the generated compile commands: fmt and spdlog omit `-Werror`; `nvat`, `nvattest`, and both test targets retain it and use the two vendored roots via `-isystem`
